### PR TITLE
Changement de l'IP détecté chez infomaniak

### DIFF
--- a/api/config.init.php
+++ b/api/config.init.php
@@ -38,8 +38,8 @@ else setlocale(LC_ALL, 'en_US.utf8');
 
 // Serveur local ou online ? DEV || PROD
 if(
-	strpos($_SERVER['SERVER_ADDR'], '::1') !== false or
-	strpos($_SERVER['SERVER_ADDR'], '127.0') !== false)
+ $_SERVER['SERVER_ADDR'] == '127.0.0.1' or
+ strpos($_SERVER['SERVER_ADDR'], '::1') !== false)
 	$dev = true;
 else 
 	$dev = false;


### PR DESCRIPTION
Quand on livre un site chez Infomniak, on trouve seulement l'IP local et non l'IPv4 (peut-être une évolution de sécurité de leur côté). Je change donc la detection de l'IP lorsque l'on travail en local