### PR TITLE
Ne supprime que les div vides lors du copier-coller

### DIFF
--- a/api/lucide.edit.js
+++ b/api/lucide.edit.js
@@ -3325,6 +3325,9 @@ $(function()
 
 					// Supprime les styles et class
 					.replace(/(style|class)=(["'])(.*?)(["'])/g, '')// style="[^"]*"
+			
+					// Supprimeles <div></div>
+					.replace(/<div[^>]*>(\s|&nbsp;|<\/?\s?br\s?\/?>)*<\/?div>/g, '')
 
 
 			// Transforme les retours à la ligne en <br>
@@ -3334,7 +3337,7 @@ $(function()
 			//paste = paste.replace(/<br><\/p>/gi, '</p>');// /!\ Ne fonctionne pas
 
 			// Clean les tags en gardant certain élément de mise en page //@todo voir le cas des <p></p>
-			paste = strip_tags(paste, "<p></p><a></a><b><b/><i></i><h1></h1><h2></h2><h3></h3><h4></h4><ul></ul><li></li><br>");
+			paste = strip_tags(paste, "<div></div><p></p><a></a><b><b/><i></i><h1></h1><h2></h2><h3></h3><h4></h4><ul></ul><li></li><br>");
 			
 			// Supprime les paragraphes avec juste un espace insécable
 			paste = paste.replace(/<p[^>]*> <\/p>/g, '').replace(/<p[^>]*>&nbsp;<\/p>/g, '');


### PR DESCRIPTION
Évite la suppression des div lors d'un copier-coller, car ils peuvent avoir un id de référence : cas repéré lors d'un copier-coller d'un Word  avec des références en bas de page.